### PR TITLE
feat: Add script for making API calls from CSV file

### DIFF
--- a/csvcurl
+++ b/csvcurl
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Check if the correct number of arguments is provided
+if [ "$#" -lt 4 ]; then
+  echo "Usage: $0 <api_url> <file_path> <jwt> <column_mappings>"
+  echo "Example: $0 'https://api.example.com/resource/{uuid}/{name}' 'uuids.csv' 'your_jwt_token' 'uuid=0,name=1'"
+  exit 1
+fi
+
+# Assign arguments to variables
+api_url=$1
+file=$2
+jwt=$3
+column_mappings=$4
+
+# Parse column mappings into an associative array
+declare -A mappings
+IFS=',' read -ra pairs <<< "$column_mappings"
+for pair in "${pairs[@]}"; do
+  IFS='=' read -ra kv <<< "$pair"
+  mappings[${kv[0]}]=${kv[1]}
+done
+
+# Read the file line by line
+while IFS=, read -r -a columns || [[ -n "$columns" ]]; do
+  # Construct the API URL by replacing placeholders with actual values from the CSV
+  url=$api_url
+  for key in "${!mappings[@]}"; do
+    value=${columns[${mappings[$key]}]}
+    url=${url//\{$key\}/$value}
+  done
+
+  # Print the constructed URL
+  echo "URL: $url"
+
+  # Make a curl call with the constructed URL
+  curl --location --request GET "$url" --header "Authorization: Bearer $jwt"
+done < "$file"


### PR DESCRIPTION
This commit adds a new script, csvcurl, which allows making API calls using data from a CSV file. The script takes four arguments: the API URL, the file path of the CSV, a JWT token, and column mappings for the CSV data. It checks if the correct number of arguments is provided and exits with an error message if not.

The script parses the column mappings into an associative array and reads the CSV file line by line. It constructs the API URL by replacing placeholders with actual values from the CSV. It then prints the constructed URL and makes a curl call with the constructed URL, using the provided JWT token for authorization.

This script will be useful for automating API calls using data from a CSV file.